### PR TITLE
[#4] 회원가입 API 개발

### DIFF
--- a/src/main/java/com/flab/vibeup/config/SecurityConfig.java
+++ b/src/main/java/com/flab/vibeup/config/SecurityConfig.java
@@ -2,10 +2,12 @@ package com.flab.vibeup.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -16,9 +18,15 @@ public class SecurityConfig {
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/health/**", "/actuator/**").permitAll()
-                        .anyRequest().authenticated()
-                ).httpBasic(Customizer.withDefaults());
+                .requestMatchers(HttpMethod.POST, "/api/v1/users/signup").permitAll()
+                .requestMatchers("/actuator/**", "/health/**", "/error").permitAll()
+                .anyRequest().authenticated()
+        );
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(); // 기본 추천
     }
 }

--- a/src/main/java/com/flab/vibeup/domain/user/UserService.java
+++ b/src/main/java/com/flab/vibeup/domain/user/UserService.java
@@ -1,4 +1,0 @@
-package com.flab.vibeup.domain.user;
-
-public class UserService {
-}

--- a/src/main/java/com/flab/vibeup/domain/user/controller/UserController.java
+++ b/src/main/java/com/flab/vibeup/domain/user/controller/UserController.java
@@ -1,0 +1,26 @@
+package com.flab.vibeup.domain.user.controller;
+
+import com.flab.vibeup.domain.user.dto.UserResponse;
+import com.flab.vibeup.domain.user.dto.UserSignupRequest;
+import com.flab.vibeup.domain.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<UserResponse> signup(@RequestBody @Valid UserSignupRequest request) {
+        UserResponse resp = userService.signup(request);
+        return ResponseEntity.ok(resp);
+    }
+}

--- a/src/main/java/com/flab/vibeup/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/flab/vibeup/domain/user/dto/UserResponse.java
@@ -1,0 +1,8 @@
+package com.flab.vibeup.domain.user.dto;
+
+public record UserResponse(
+        Long id,
+        String email,
+        String username,
+        String nickname
+) {}

--- a/src/main/java/com/flab/vibeup/domain/user/dto/UserSignupRequest.java
+++ b/src/main/java/com/flab/vibeup/domain/user/dto/UserSignupRequest.java
@@ -1,0 +1,12 @@
+package com.flab.vibeup.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserSignupRequest(
+        @Email @NotBlank String email,
+        @NotBlank @Size(min = 3, max = 20) String username,
+        @NotBlank @Size(min = 8, max = 64) String password,
+        @NotBlank String nickname
+) {}

--- a/src/main/java/com/flab/vibeup/domain/user/entity/User.java
+++ b/src/main/java/com/flab/vibeup/domain/user/entity/User.java
@@ -1,4 +1,4 @@
-package com.flab.vibeup.domain.user;
+package com.flab.vibeup.domain.user.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/flab/vibeup/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/flab/vibeup/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
-package com.flab.vibeup.domain.user;
+package com.flab.vibeup.domain.user.repository;
 
+import com.flab.vibeup.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/flab/vibeup/domain/user/service/UserService.java
+++ b/src/main/java/com/flab/vibeup/domain/user/service/UserService.java
@@ -1,0 +1,36 @@
+package com.flab.vibeup.domain.user.service;
+
+import com.flab.vibeup.domain.user.dto.UserResponse;
+import com.flab.vibeup.domain.user.dto.UserSignupRequest;
+import com.flab.vibeup.domain.user.entity.User;
+import com.flab.vibeup.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public UserResponse signup(UserSignupRequest req) {
+        //중복 체크 & 비즈니스로직
+        userRepository.findByEmail(req.email())
+                .ifPresent(u -> { throw new IllegalArgumentException("이미 사용중인 이메일입니다."); });
+        userRepository.findByNickname(req.nickname())
+                .ifPresent(u -> { throw new IllegalArgumentException("이미 사용중인 닉네임입니다."); } );
+        String hashed = passwordEncoder.encode(req.password());
+        User user = User.builder()
+                .email(req.email())
+                .name(req.username())
+                .password(hashed)
+                .nickname(req.nickname())
+                .build();
+        User saved = userRepository.save(user);
+        return new UserResponse(saved.getId(), saved.getEmail(), saved.getName(), saved.getNickname());
+    }
+}

--- a/src/main/java/com/flab/vibeup/domain/user/service/UserService.java
+++ b/src/main/java/com/flab/vibeup/domain/user/service/UserService.java
@@ -18,11 +18,6 @@ public class UserService {
 
     @Transactional
     public UserResponse signup(UserSignupRequest req) {
-        //중복 체크 & 비즈니스로직
-        userRepository.findByEmail(req.email())
-                .ifPresent(u -> { throw new IllegalArgumentException("이미 사용중인 이메일입니다."); });
-        userRepository.findByNickname(req.nickname())
-                .ifPresent(u -> { throw new IllegalArgumentException("이미 사용중인 닉네임입니다."); } );
         String hashed = passwordEncoder.encode(req.password());
         User user = User.builder()
                 .email(req.email())

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,3 +38,4 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+    org.springframework.security: DEBUG

--- a/src/main/resources/db/migration/V1__create_users.sql
+++ b/src/main/resources/db/migration/V1__create_users.sql
@@ -1,0 +1,9 @@
+CREATE TABLE users (
+    id BIGSERIAL PRIMARY KEY,  -- 자동 증가 PK
+    email VARCHAR(100) NOT NULL UNIQUE,   -- 이메일 (Unique)
+    nickname VARCHAR(50) NOT NULL UNIQUE,  -- 닉네임 (Unique)
+    password VARCHAR(255) NOT NULL,    -- 비밀번호
+    name VARCHAR(50), -- 이름 (옵션)
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, -- 생성일시
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP -- 수정일시
+);

--- a/src/test/java/com/flab/vibeup/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/flab/vibeup/domain/user/service/UserServiceTest.java
@@ -1,0 +1,99 @@
+package com.flab.vibeup.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.flab.vibeup.domain.user.dto.UserSignupRequest;
+import com.flab.vibeup.domain.user.entity.User;
+import com.flab.vibeup.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock PasswordEncoder passwordEncoder;
+
+    @InjectMocks UserService userService;
+
+    private UserSignupRequest req() {
+        return new UserSignupRequest(
+                "hyeonsuns@kakao.com",
+                "Hyeonsun Jung",
+                "password1234!",
+                "HS JUNG"
+        );
+    }
+
+    @Test
+    @DisplayName("정상 회원가입 테스트 : 새로운 이메일/닉네임이면 신규저장, 비밀번호는 인코딩")
+    void signup_success() {
+        var request = req();
+        // given
+        given(passwordEncoder.encode(anyString())).willReturn("encoded");
+        var saved = User.builder()
+                .id(1L)
+                .email(request.email())
+                .nickname(request.nickname())
+                .password("encoded") // password encoded mock 처리
+                .build();
+        given(userRepository.save(any(User.class))).willReturn(saved); // save 객체를 DB적재 하지 않고 그대로 리턴
+
+        // when
+        var resp = userService.signup(request);
+
+        // then
+        then(passwordEncoder).should().encode(request.password());
+        then(userRepository).should().save(any(User.class));
+        assertThat(resp.id()).isEqualTo(1L);
+        assertThat(resp.email()).isEqualTo("hyeonsuns@kakao.com");
+        assertThat(resp.nickname()).isEqualTo("HS JUNG");
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 테스트 : 이메일 / 닉네임 중복저장")
+    void signup_fail_when_unique_constraint_violated() {
+        //given
+        var request = req();
+        given(passwordEncoder.encode(anyString())).willReturn("encoded");
+        //저장할 때 DB 제약위반 상황 가정
+        given(userRepository.save(any(User.class)))
+                .willThrow(new DataIntegrityViolationException("Unique Constraint"));
+
+        //when, then
+        assertThatThrownBy(() -> userService.signup(request))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        then(passwordEncoder).should().encode(request.password());
+        then(userRepository).should().save(any(User.class));
+        verifyNoMoreInteractions(passwordEncoder, userRepository);
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 테스트 : 비밀번호 암호화 실패")
+    void signup_fail_password_encoding() {
+        //given
+        var request = req();
+        given(passwordEncoder.encode(anyString()))
+                .willThrow(new IllegalStateException("encoder fail"));
+
+        //when, then
+        assertThatThrownBy(() -> userService.signup(request))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("encoder fail");
+
+        // save가 되지 않아야함
+        then(userRepository).shouldHaveNoInteractions();
+    }
+}


### PR DESCRIPTION
#4 Pull Request
•  UserSignupRequest DTO 생성
• @NotBlank, @Email 등 유효성 검증 추가
• UserResponse DTO 생성
• 비밀번호 제외한 안전한 응답 제공
• UserController.signup() 구현
• 회원가입 요청 처리 및 JPA UserRepository.save() 호출
• BCryptPasswordEncoder를 사용하여 비밀번호 암호화 저장
• Spring 기본 MethodArgumentNotValidException 으로 Validation 오류 응답 처리
<img width="698" height="556" alt="image" src="https://github.com/user-attachments/assets/c5438045-7286-4a00-8aaa-6ddb3319a81c" />
<img width="1194" height="101" alt="image" src="https://github.com/user-attachments/assets/6ba8175f-761a-4fbb-bbf4-1edcbbde4ba7" />
