### PR TITLE
Feature/5 login jwt

### DIFF
--- a/src/main/java/com/flab/vibeup/auth/JwtTokenProvider.java
+++ b/src/main/java/com/flab/vibeup/auth/JwtTokenProvider.java
@@ -1,0 +1,62 @@
+package com.flab.vibeup.auth;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtTokenProvider {
+    // 토큰 발급 / 검증
+    private final Key key;  // 서명에 사용할 HMAC SecretKey
+    private final long validityMs; // 토큰 유효기간
+
+    public JwtTokenProvider( // application.yml 의 값 주입
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-validity-seconds}") long validitySeconds
+    ) {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+        this.validityMs = validitySeconds * 1000L;
+    }
+
+    // Access Token 발급
+    public String createToken(String subject, Map<String, Object> claims) {
+        Date now = new Date();
+        Date exp = new Date(now.getTime() + validityMs);
+        return Jwts.builder()
+                .setSubject(subject)  // email
+                .addClaims(claims)    // id, role
+                .setIssuedAt(now)     // key issued time
+                .setExpiration(exp)   // key expiration time
+                .signWith(key, SignatureAlgorithm.HS256)  // HMAC-SHA256 서명
+                .compact(); // 최종 JWT Access Token 문자열 생성
+    }
+
+    // Token Parsing, 서명 검증
+    public Jws<Claims> parse(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    // Token Validation (Parse)
+    public boolean validate(String token) {
+        try {
+            parse(token);
+            return true;
+        } catch(JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    // 인증 시 email 확인할 때 사용
+    public String getSubject(String token) {
+        return parse(token).getBody().getSubject();
+    }
+}

--- a/src/main/java/com/flab/vibeup/domain/user/controller/AuthController.java
+++ b/src/main/java/com/flab/vibeup/domain/user/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.flab.vibeup.domain.user.controller;
+
+import com.flab.vibeup.domain.user.dto.LoginRequest;
+import com.flab.vibeup.domain.user.dto.LoginResponse;
+import com.flab.vibeup.domain.user.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    public AuthController(AuthService authService) { this.authService = authService; }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+}

--- a/src/main/java/com/flab/vibeup/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/flab/vibeup/domain/user/dto/LoginRequest.java
@@ -1,0 +1,10 @@
+package com.flab.vibeup.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+// 로그인 요청
+public record LoginRequest(
+        @Email @NotBlank String email,
+        @NotBlank String password
+) {}

--- a/src/main/java/com/flab/vibeup/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/flab/vibeup/domain/user/dto/LoginResponse.java
@@ -1,0 +1,4 @@
+package com.flab.vibeup.domain.user.dto;
+
+// 로그인 응답(액세스토큰 반환)
+public record LoginResponse(String accessToken,long expiresInSeconds) {}

--- a/src/main/java/com/flab/vibeup/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/flab/vibeup/domain/user/repository/UserRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
-    Optional<User> findByNickname(String nickname);
+    Optional<User> findByEmail(String email); // 로그인 이메일 검증용
 }

--- a/src/main/java/com/flab/vibeup/domain/user/service/AuthService.java
+++ b/src/main/java/com/flab/vibeup/domain/user/service/AuthService.java
@@ -1,0 +1,42 @@
+package com.flab.vibeup.domain.user.service;
+
+import com.flab.vibeup.auth.JwtTokenProvider;
+import com.flab.vibeup.domain.user.dto.LoginRequest;
+import com.flab.vibeup.domain.user.dto.LoginResponse;
+import com.flab.vibeup.domain.user.entity.User;
+import com.flab.vibeup.domain.user.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthService(UserRepository userRepository,
+                       PasswordEncoder passwordEncoder,
+                       JwtTokenProvider jwtTokenProvider) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public LoginResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));
+
+        if(!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new IllegalArgumentException("Invalid credentials");
+        }
+
+        String token  = jwtTokenProvider.createToken(
+                user.getEmail(),
+                Map.of("role", "USER", "uid", user.getId())
+        );
+        return new LoginResponse(token, 3600);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,6 +23,10 @@ spring:
         default_batch_fetch_size: 100
     show-sql: true                  # 콘솔에 SQL 출력 (dev 전용)
 
+jwt:
+  secret: "aUCYJ7HwUTSjUqs6dvbZxu6Cf+XyOkO3yhDGT3LTwHc="
+  access-validity-seconds: 3600
+
 
 # Actuator(헬스 등) 개발에서만 노출
 management:

--- a/src/test/java/com/flab/vibeup/auth/JwtTokenProviderTest.java
+++ b/src/test/java/com/flab/vibeup/auth/JwtTokenProviderTest.java
@@ -1,0 +1,40 @@
+package com.flab.vibeup.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import java.util.Base64;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 시크릿키 : 256bit이상 -> Base64 encoding
+        String raw = "aUCYJ7HwUTSjUqs6dvbZxu6Cf+XyOkO3yhDGT3LTwHc=";
+        String base64 = Base64.getEncoder().encodeToString(raw.getBytes());
+        long validitySeconds = 3600;
+        jwtTokenProvider = new JwtTokenProvider(base64, validitySeconds);
+    }
+
+    @Test
+    void create_and_parse_and_validate() {
+        String subject = "hyeonsuns@kakao.com";
+        Map<String, Object> claims = Map.of("role", "USER", "uid", 123L);
+
+        String token = jwtTokenProvider.createToken(subject, claims);
+
+        assertThat(jwtTokenProvider.validate(token)).isTrue();
+        assertThat(jwtTokenProvider.getSubject(token)).isEqualTo(subject);
+
+        Jws<Claims> parsed = jwtTokenProvider.parse(token);
+        assertThat(parsed.getBody().get("role", String.class)).isEqualTo("USER");
+        assertThat(parsed.getBody().get("uid", Long.class)).isEqualTo(123L);
+    }
+
+}

--- a/src/test/java/com/flab/vibeup/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/com/flab/vibeup/domain/user/service/AuthServiceTest.java
@@ -1,0 +1,73 @@
+package com.flab.vibeup.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.flab.vibeup.auth.JwtTokenProvider;
+import com.flab.vibeup.domain.user.dto.LoginRequest;
+import com.flab.vibeup.domain.user.dto.LoginResponse;
+import com.flab.vibeup.domain.user.entity.User;
+import com.flab.vibeup.domain.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    PasswordEncoder passwordEncoder;
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks AuthService authService;
+
+    @Test
+    void login_success_returns_token() {
+        var request = new LoginRequest("hyeonsuns@kakao.com", "pw1234!");
+        var user = User.builder()
+                .id(1L)
+                .email(request.email())
+                .password("pw1234!")
+                .nickname("Hyeonsun Jung")
+                .build();
+        given(userRepository.findByEmail(request.email())).willReturn(Optional.of(user));
+        given(passwordEncoder.matches(request.password(), user.getPassword())).willReturn(true);
+        given(jwtTokenProvider.createToken(eq(user.getEmail()), anyMap())).willReturn("JWT-TOKEN"); //user email 전달
+
+        LoginResponse res = authService.login(request);
+
+        then(userRepository).should().findByEmail(request.email());
+        then(passwordEncoder).should().matches(request.password(), user.getPassword());
+        then(jwtTokenProvider).should().createToken(eq(user.getEmail()), anyMap());
+
+        assertThat(res.accessToken()).isEqualTo("JWT-TOKEN"); // 토큰은 반드시 JWT-TOKEN으로 발급 리턴
+    }
+
+    @Test
+    void login_fail_wrong_password() {
+        var request = new LoginRequest("hyeonsuns@kakao.com", "pw1234!");
+        var user = User.builder()
+                .id(1L)
+                .email(request.email())
+                .password("pw1234!")
+                .nickname("Hyeonsun Jung")
+                .build();
+        given(userRepository.findByEmail(request.email())).willReturn(Optional.of(user));
+        given(passwordEncoder.matches(request.password(), user.getPassword())).willReturn(false); // 비번 틀림
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(IllegalArgumentException.class); // 실제 IllegalArgumentException 이 발생하는지 확인
+        then(jwtTokenProvider).shouldHaveNoInteractions(); // 패스워드가 다르면 토큰발행이 되면 안됨
+    }
+}


### PR DESCRIPTION
IssueNum : #5 
**[ 검증 결과 ]**
1.  현재 DB에 회원가입 된 한건의 회원
<img width="559" height="108" alt="image" src="https://github.com/user-attachments/assets/5c5a0e69-490b-4be5-b72b-7c49cccb85f0" />

2. Login 시도
<img width="1034" height="612" alt="image" src="https://github.com/user-attachments/assets/8819ed77-2817-49a8-b5bd-b687448752bb" />
 - 정상 Access Token 발급<br><br>

**[ 구현 내용 ]**
**로그인 기능 - JWT 발급 구현**
1. JwtTokenProvider : JWT 토큰 생성, 파싱, 검증 기능 추가
2. AuthService: 로그인 시 사용자 인증 처리, 유효한 사용자라면 JwtTokenProvider를 통해 토큰 생성 및 반환
3. AuthController : /api/v1/auth/login 엔드포인트 추가, LoginRequest/LoginResponse DTO를 통해 클라이언트와 통신, 로그인 성공 시 JWT 토큰 반환
4. 테스트 코드 작성