### PR TITLE
 feat(#10): Post 엔티티 및 DTO, Repository 구현

### DIFF
--- a/src/main/java/com/flab/vibeup/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/flab/vibeup/domain/post/dto/PostCreateRequest.java
@@ -1,0 +1,12 @@
+package com.flab.vibeup.domain.post.dto;
+
+import com.flab.vibeup.domain.post.entity.MusicVendor;
+
+import java.util.List;
+
+public record PostCreateRequest(
+        MusicVendor vendor,
+        String musicUrl,
+        String caption,
+        List<String> hashtags
+) {}

--- a/src/main/java/com/flab/vibeup/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/flab/vibeup/domain/post/dto/PostResponse.java
@@ -1,0 +1,16 @@
+package com.flab.vibeup.domain.post.dto;
+
+import com.flab.vibeup.domain.post.entity.MusicVendor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostResponse(
+        Long id,
+        String nickname,
+        MusicVendor vendor,
+        String musicUrl,
+        String caption,
+        List<String> hashtags,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/flab/vibeup/domain/post/entity/MusicVendor.java
+++ b/src/main/java/com/flab/vibeup/domain/post/entity/MusicVendor.java
@@ -1,0 +1,5 @@
+package com.flab.vibeup.domain.post.entity;
+
+public enum MusicVendor {
+    YOUTUBE_MUSIC, SPOTIFY, APPLE_MUSIC, SOUNDCLOUD, ETC
+}

--- a/src/main/java/com/flab/vibeup/domain/post/entity/Post.java
+++ b/src/main/java/com/flab/vibeup/domain/post/entity/Post.java
@@ -1,0 +1,55 @@
+package com.flab.vibeup.domain.post.entity;
+
+import com.flab.vibeup.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private MusicVendor vendor;
+
+    @Column(nullable = false)
+    private String musicUrl;
+
+    private String caption;
+
+    @ElementCollection
+    @CollectionTable(name = "post_hashtags", joinColumns = @JoinColumn(name = "post_id"))
+    @Column(name = "hashtag")
+    private List<String> hashtags = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Post(MusicVendor vendor, String musicUrl, String caption, User user) {
+        this.vendor = vendor;
+        this.musicUrl = musicUrl;
+        this.caption = caption;
+        this.user = user;
+    }
+
+    public void updateCaption(String newCaption) {
+        this.caption = newCaption;
+    }
+}

--- a/src/main/java/com/flab/vibeup/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/flab/vibeup/domain/post/repository/PostRepository.java
@@ -1,0 +1,10 @@
+package com.flab.vibeup.domain.post.repository;
+
+import com.flab.vibeup.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findAllByUserId(Long userId);
+}


### PR DESCRIPTION
Post 기능 구현을 위한 초기 설정 작업을 진행했습니다.

## 주요 변경 사항
- `Post` 엔티티 정의
  - `vendor`, `musicUrl`, `caption`, `hashtags`, `createdAt` 필드 포함
  - `User` 엔티티와의 연관관계 설정 (N:1)
  - `hashtags`는 `@ElementCollection`으로 구현
- 생성 시 자동 `createdAt` 설정 (@PrePersist)
- `PostRepository` 인터페이스 생성
- 테스트용 기본 생성자 및 caption 수정 메서드 추가

## 기타
- 음악 관련 포스트임을 고려하여 MusicVendor enum도 정의
- 추후 Post 관련 서비스 로직 및 API 개발 예정