### PR TITLE
포스트 Create 구현(#12)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 	// --- Test ---
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.mockito:mockito-inline:5.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/flab/vibeup/domain/post/controller/PostController.java
+++ b/src/main/java/com/flab/vibeup/domain/post/controller/PostController.java
@@ -1,0 +1,27 @@
+package com.flab.vibeup.domain.post.controller;
+
+import com.flab.vibeup.domain.post.dto.PostCreateRequest;
+import com.flab.vibeup.domain.post.service.PostService;
+import com.flab.vibeup.global.auth.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<Void> createPost(@RequestBody @Valid PostCreateRequest request, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        postService.createPost(request, userDetails.getUserId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/flab/vibeup/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/flab/vibeup/domain/post/dto/PostCreateRequest.java
@@ -1,12 +1,14 @@
 package com.flab.vibeup.domain.post.dto;
 
 import com.flab.vibeup.domain.post.entity.MusicVendor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
 public record PostCreateRequest(
-        MusicVendor vendor,
-        String musicUrl,
+        @NotNull MusicVendor vendor,
+        @NotBlank String musicUrl,
         String caption,
         List<String> hashtags
 ) {}

--- a/src/main/java/com/flab/vibeup/domain/post/service/PostService.java
+++ b/src/main/java/com/flab/vibeup/domain/post/service/PostService.java
@@ -5,7 +5,6 @@ import com.flab.vibeup.domain.post.dto.PostCreateRequest;
 import com.flab.vibeup.domain.post.entity.Post;
 import com.flab.vibeup.domain.post.repository.PostRepository;
 import com.flab.vibeup.domain.user.entity.User;
-import com.flab.vibeup.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,12 +14,10 @@ import org.springframework.stereotype.Service;
 public class PostService {
 
     private final PostRepository postRepository;
-    private final UserRepository userRepository;
 
     @Transactional
     public Long createPost(PostCreateRequest request, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        User user = User.builder().id(userId).build();
 
         Post post = Post.builder()
                 .user(user)

--- a/src/main/java/com/flab/vibeup/domain/post/service/PostService.java
+++ b/src/main/java/com/flab/vibeup/domain/post/service/PostService.java
@@ -1,0 +1,36 @@
+
+package com.flab.vibeup.domain.post.service;
+
+import com.flab.vibeup.domain.post.dto.PostCreateRequest;
+import com.flab.vibeup.domain.post.entity.Post;
+import com.flab.vibeup.domain.post.repository.PostRepository;
+import com.flab.vibeup.domain.user.entity.User;
+import com.flab.vibeup.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long createPost(PostCreateRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Post post = Post.builder()
+                .user(user)
+                .musicUrl(request.musicUrl())
+                .vendor(request.vendor())
+                .caption(request.caption())
+                .hashtags(request.hashtags())
+                .build();
+
+        Post savedPost = postRepository.save(post);
+        return savedPost.getId();
+    }
+}

--- a/src/main/java/com/flab/vibeup/global/auth/CustomUserDetails.java
+++ b/src/main/java/com/flab/vibeup/global/auth/CustomUserDetails.java
@@ -1,0 +1,55 @@
+package com.flab.vibeup.global.auth;
+
+import com.flab.vibeup.domain.user.entity.User;
+import java.util.Collection;
+import java.util.Collections;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public Long getUserId() {
+        return user.getId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList(); // 권한 Empty 처리
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/flab/vibeup/global/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/flab/vibeup/global/auth/CustomUserDetailsService.java
@@ -1,0 +1,23 @@
+package com.flab.vibeup.global.auth;
+
+import com.flab.vibeup.domain.user.entity.User;
+import com.flab.vibeup.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("이메일을 찾을 수 없습니다: " + email));
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/test/java/com/flab/vibeup/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/flab/vibeup/domain/post/service/PostServiceTest.java
@@ -1,0 +1,60 @@
+package com.flab.vibeup.domain.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.flab.vibeup.domain.post.dto.PostCreateRequest;
+import com.flab.vibeup.domain.post.entity.MusicVendor;
+import com.flab.vibeup.domain.post.entity.Post;
+import com.flab.vibeup.domain.post.repository.PostRepository;
+import com.flab.vibeup.domain.user.entity.User;
+import com.flab.vibeup.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Transactional
+class PostServiceTest {
+
+  @Autowired private PostService postService;
+
+  @Autowired private PostRepository postRepository;
+
+  @Autowired private UserRepository userRepository;
+
+  @Test
+  @DisplayName("포스트 생성 요청 시, 게시글이 저장되고 userId가 반환된다")
+  void createPost_shouldSavePostAndReturnUserId() {
+    // given
+    User user =
+        User.builder()
+            .email("test@example.com")
+            .password("secure1234")
+            .name("Jason")
+            .nickname("testUser")
+            .build();
+    userRepository.save(user);
+
+    PostCreateRequest request =
+        new PostCreateRequest(
+            MusicVendor.YOUTUBE_MUSIC,
+            "https://youtube.com/testmusic",
+            "이 노래 추천!!",
+            List.of("감성", "추천"));
+
+    // when
+    Long savedPostId = postService.createPost(request, user.getId());
+    Post savedPost = postRepository.findById(savedPostId)
+            .orElseThrow(() -> new IllegalStateException("Post not found"));
+
+    // then
+    assertThat(savedPost).isNotNull();
+    assertThat(user.getId()).isEqualTo(savedPost.getUser().getId());
+    assertThat(savedPost.getMusicUrl()).isEqualTo(request.musicUrl());
+    assertThat(savedPost.getHashtags()).containsExactly("감성", "추천");
+    assertThat(savedPost.getVendor()).isEqualTo(MusicVendor.YOUTUBE_MUSIC);
+  }
+}


### PR DESCRIPTION
- PostController에 POST /api/posts 엔드포인트 구현
- PostService에 게시글 저장 로직 추가
- 인증된 사용자의 ID를 기반으로 작성자 연동
- CustomUserDetails에서 사용자 ID 추출 방식 적용
- PostCreateRequest DTO 및 관련 테스트 코드 작성 완료

Closes #12 

- 추후 hashtag 확장 고려 (현재는 String 리스트로 처리)