### PR TITLE
Feature/21 23 feed module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
 	runtimeOnly   'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly   'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// --- Redis ---
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'org.apache.commons:commons-pool2'
+
 	// --- Utils ---
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/flab/vibeup/config/RedisConfig.java
+++ b/src/main/java/com/flab/vibeup/config/RedisConfig.java
@@ -1,0 +1,24 @@
+package com.flab.vibeup.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        // localhost:6379
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, Long> redisTemplate() {
+        RedisTemplate<String, Long> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        return template;
+    }
+}

--- a/src/main/java/com/flab/vibeup/domain/post/controller/PostController.java
+++ b/src/main/java/com/flab/vibeup/domain/post/controller/PostController.java
@@ -60,4 +60,15 @@ public class PostController {
     postService.deletePost(postId, userDetails.getUserId());
     return ResponseEntity.noContent().build();
   }
+
+  @GetMapping("/feeds")
+  public ResponseEntity<Page<PostListResponse>> getFeeds(Pageable pageable) {
+    return ResponseEntity.ok(postService.getFeeds(pageable));
+  }
+
+  @GetMapping("/feeds/users/{userId}")
+  public ResponseEntity<Page<PostListResponse>> getFeedsByUser(
+      @PathVariable Long userId, Pageable pageable) {
+    return ResponseEntity.ok(postService.getFeedsByUser(userId, pageable));
+  }
 }

--- a/src/main/java/com/flab/vibeup/domain/post/dto/PostListResponse.java
+++ b/src/main/java/com/flab/vibeup/domain/post/dto/PostListResponse.java
@@ -1,6 +1,7 @@
 package com.flab.vibeup.domain.post.dto;
 
 import com.flab.vibeup.domain.post.entity.MusicVendor;
+import com.flab.vibeup.domain.post.entity.Post;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -13,4 +14,15 @@ public record PostListResponse(
         String caption,
         String userNickname,
         LocalDateTime createdAt
-) {}
+) {
+    public static PostListResponse from(Post post) {
+        return PostListResponse.builder()
+                .postId(post.getId())
+                .musicUrl(post.getMusicUrl())
+                .vendor(post.getVendor())
+                .caption(post.getCaption())
+                .userNickname(post.getUser().getNickname())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/flab/vibeup/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/flab/vibeup/domain/post/repository/PostRepository.java
@@ -1,10 +1,16 @@
 package com.flab.vibeup.domain.post.repository;
 
 import com.flab.vibeup.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByUserId(Long userId);
+
+    Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable); // 최신순 피드 조회
+
+    Page<Post> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable); // 특정 유저의 피드 조회
 }

--- a/src/main/java/com/flab/vibeup/domain/post/service/PostService.java
+++ b/src/main/java/com/flab/vibeup/domain/post/service/PostService.java
@@ -90,4 +90,16 @@ public class PostService {
     }
     postRepository.delete(post);
   }
+
+  @Transactional(readOnly = true)
+  public Page<PostListResponse> getFeeds(Pageable pageable) {
+    return postRepository.findAllByOrderByCreatedAtDesc(pageable).map(PostListResponse::from);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<PostListResponse> getFeedsByUser(Long userId, Pageable pageable) {
+    return postRepository
+        .findAllByUserIdOrderByCreatedAtDesc(userId, pageable)
+        .map(PostListResponse::from);
+  }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,6 +23,10 @@ spring:
         default_batch_fetch_size: 100
     show-sql: true                  # 콘솔에 SQL 출력 (dev 전용)
 
+  redis:
+    host: localhost
+    port: 6379
+
 jwt:
   secret: "aUCYJ7HwUTSjUqs6dvbZxu6Cf+XyOkO3yhDGT3LTwHc="
   access-validity-seconds: 3600

--- a/src/test/java/com/flab/vibeup/config/RedisConnectionTest.java
+++ b/src/test/java/com/flab/vibeup/config/RedisConnectionTest.java
@@ -1,0 +1,21 @@
+package com.flab.vibeup.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class RedisConnectionTest {
+    @Autowired
+    private RedisTemplate<String, Long> redisTemplate;
+
+    @Test
+    void redisPushAndPullTest() {
+        redisTemplate.opsForList().leftPush("feed:1", 100L);
+        Long postId = redisTemplate.opsForList().leftPop("feed:1");
+        assertThat(postId).isEqualTo(100L);
+    }
+}

--- a/src/test/java/com/flab/vibeup/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/flab/vibeup/domain/post/service/PostServiceTest.java
@@ -12,6 +12,7 @@ import com.flab.vibeup.domain.post.repository.PostRepository;
 import com.flab.vibeup.domain.user.entity.User;
 import com.flab.vibeup.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -176,5 +177,87 @@ class PostServiceTest {
     // then
     boolean exists = postRepository.existsById(savedPostId);
     assertThat(exists).isFalse();
+  }
+
+  @Test
+  @DisplayName("피드 조회 요청 시, 최신순으로 정렬된 게시글 목록이 반환된다")
+  void getFeed_shouldReturnPostsInDescendingOrder() {
+    // given
+    for (int i = 1; i <= 5; i++) {
+      PostCreateRequest request =
+          new PostCreateRequest(
+              MusicVendor.YOUTUBE_MUSIC,
+              "https://youtube.com/music" + i,
+              "추천곡 " + i,
+              List.of("HashTag" + i));
+      postService.createPost(request, savedUser.getId());
+      try {
+        Thread.sleep(50); // 정렬을 위한 시간 확보
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    // when
+    Pageable pageable = PageRequest.of(0, 3); // 최신 3개
+    Page<PostListResponse> feed = postService.getFeeds(pageable);
+
+    // then
+    assertThat(feed).isNotNull();
+    assertThat(feed.getContent()).hasSize(3);
+
+    List<PostListResponse> contents = feed.getContent();
+    for (int i = 0; i < contents.size() - 1; i++) {
+      assertThat(contents.get(i).createdAt()).isAfterOrEqualTo(contents.get(i + 1).createdAt());
+    }
+  }
+
+  @DisplayName("유저 기반 최신순 피드 조회 테스트")
+  @Test
+  void getFeedByUserId_ShouldReturnFeedsSortedByCreatedAtDesc() {
+    // given
+    Post post1 = Post.builder()
+            .user(savedUser)
+            .musicUrl("https://test.com/1")
+            .vendor(MusicVendor.YOUTUBE_MUSIC)
+            .caption("caption1")
+            .hashtags(List.of("tag1", "tag2"))
+            .createdAt(LocalDateTime.now().minusMinutes(10))
+            .build();
+
+    Post post2 = Post.builder()
+            .user(savedUser)
+            .musicUrl("https://test.com/2")
+            .vendor(MusicVendor.YOUTUBE_MUSIC)
+            .caption("caption2")
+            .hashtags(List.of("tag1", "tag2"))
+            .createdAt(LocalDateTime.now().minusMinutes(5))
+            .build();
+
+    Post post3 = Post.builder()
+            .user(savedUser)
+            .musicUrl("https://test.com/3")
+            .vendor(MusicVendor.YOUTUBE_MUSIC)
+            .caption("caption3")
+            .hashtags(List.of("tag1", "tag2"))
+            .createdAt(LocalDateTime.now())
+            .build();
+
+    postRepository.saveAll(List.of(post1, post2, post3));
+
+    Pageable pageable = PageRequest.of(0, 3); // 최신 3개
+
+    // when
+    Page<PostListResponse> feedPage = postService.getFeedsByUser(savedUser.getId(), pageable);
+
+    // then
+    assertThat(feedPage).hasSize(3);
+
+    List<PostListResponse> feed = feedPage.getContent();
+    assertThat(feed.get(0).createdAt()).isAfter(feed.get(1).createdAt());
+    assertThat(feed.get(1).createdAt()).isAfter(feed.get(2).createdAt());
+
+    assertThat(feed.get(0).musicUrl()).isEqualTo("https://test.com/3");
+    assertThat(feed.get(2).musicUrl()).isEqualTo("https://test.com/1");
   }
 }


### PR DESCRIPTION
### 📌 작업 개요
- 피드 조회 기능(최신순 / 유저 기반 최신순) API 구현 및 단위 테스트 작성

### ✅ 주요 변경사항
- `PostService`에 최신순 피드 조회(getFeeds) 및 유저 기반 피드 조회(getFeedsByUser) 로직 추가
- `PostRepository`에 createdAt 기준 내림차순 정렬 메서드 정의
- `PostServiceTest` 내 단위 테스트 작성:
  - 최신순 피드 조회 검증 (`getFeed_shouldReturnPostsInDescendingOrder`)
  - 유저 기반 피드 조회 검증 (`getFeedByUserId_ShouldReturnFeedsSortedByCreatedAtDesc`)

### 🧪 테스트
- `PostServiceTest` 통과 확인
  - 피드가 `createdAt DESC` 기준으로 정렬되어 반환됨
  - 유저별 필터링 및 페이지네이션 정상 동작 확인

### 🧩 관련 이슈
- Close #22  Feed 조회 API 구현 (최신순/유저 기반)  
- Close #23  Feed 조회 단위 테스트 작성