### PR TITLE
Feed Fanout & 호출 로직 구현 (with Unit test) (#21 #22 #23)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
 	runtimeOnly   'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly   'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// --- Redis ---
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'org.apache.commons:commons-pool2'
+
 	// --- Utils ---
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/flab/vibeup/config/RedisConfig.java
+++ b/src/main/java/com/flab/vibeup/config/RedisConfig.java
@@ -1,0 +1,24 @@
+package com.flab.vibeup.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        // localhost:6379
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, Long> redisTemplate() {
+        RedisTemplate<String, Long> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        return template;
+    }
+}

--- a/src/main/java/com/flab/vibeup/domain/follow/entity/Follow.java
+++ b/src/main/java/com/flab/vibeup/domain/follow/entity/Follow.java
@@ -1,0 +1,24 @@
+package com.flab.vibeup.domain.follow.entity;
+
+import com.flab.vibeup.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "follow")
+@Builder
+public class Follow {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User follower;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User followee;
+}

--- a/src/main/java/com/flab/vibeup/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/flab/vibeup/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,10 @@
+package com.flab.vibeup.domain.follow.repository;
+
+import com.flab.vibeup.domain.follow.entity.Follow;
+import com.flab.vibeup.domain.user.entity.User;
+
+import java.util.List;
+
+public interface FollowRepository {
+    List<Follow> findAllByFollowee(User followee);
+}

--- a/src/main/java/com/flab/vibeup/domain/post/controller/PostController.java
+++ b/src/main/java/com/flab/vibeup/domain/post/controller/PostController.java
@@ -11,10 +11,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Objects;
 
 @RestController
 @RequestMapping("/api/posts")
@@ -22,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class PostController {
 
   private final PostService postService;
+  private final RedisTemplate<String, String> redisTemplate;
 
   @PostMapping
   public ResponseEntity<Void> createPost(
@@ -62,8 +68,14 @@ public class PostController {
   }
 
   @GetMapping("/feeds")
-  public ResponseEntity<Page<PostListResponse>> getFeeds(Pageable pageable) {
-    return ResponseEntity.ok(postService.getFeeds(pageable));
+  public ResponseEntity<List<Long>> getFeeds(Authentication authentication) {
+    CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+    Long userId = userDetails.getUserId();
+
+    List<String> postIdStrings = redisTemplate.opsForList().range("feed:" + userId, 0, 9); // 최근 10개
+    List<Long> postIds = Objects.requireNonNull(postIdStrings).stream().map(Long::valueOf).toList();
+
+    return ResponseEntity.ok(postIds);
   }
 
   @GetMapping("/feeds/users/{userId}")

--- a/src/main/java/com/flab/vibeup/domain/post/controller/PostController.java
+++ b/src/main/java/com/flab/vibeup/domain/post/controller/PostController.java
@@ -60,4 +60,15 @@ public class PostController {
     postService.deletePost(postId, userDetails.getUserId());
     return ResponseEntity.noContent().build();
   }
+
+  @GetMapping("/feeds")
+  public ResponseEntity<Page<PostListResponse>> getFeeds(Pageable pageable) {
+    return ResponseEntity.ok(postService.getFeeds(pageable));
+  }
+
+  @GetMapping("/feeds/users/{userId}")
+  public ResponseEntity<Page<PostListResponse>> getFeedsByUser(
+      @PathVariable Long userId, Pageable pageable) {
+    return ResponseEntity.ok(postService.getFeedsByUser(userId, pageable));
+  }
 }

--- a/src/main/java/com/flab/vibeup/domain/post/dto/PostListResponse.java
+++ b/src/main/java/com/flab/vibeup/domain/post/dto/PostListResponse.java
@@ -1,6 +1,7 @@
 package com.flab.vibeup.domain.post.dto;
 
 import com.flab.vibeup.domain.post.entity.MusicVendor;
+import com.flab.vibeup.domain.post.entity.Post;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -13,4 +14,15 @@ public record PostListResponse(
         String caption,
         String userNickname,
         LocalDateTime createdAt
-) {}
+) {
+    public static PostListResponse from(Post post) {
+        return PostListResponse.builder()
+                .postId(post.getId())
+                .musicUrl(post.getMusicUrl())
+                .vendor(post.getVendor())
+                .caption(post.getCaption())
+                .userNickname(post.getUser().getNickname())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/flab/vibeup/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/flab/vibeup/domain/post/repository/PostRepository.java
@@ -1,10 +1,16 @@
 package com.flab.vibeup.domain.post.repository;
 
 import com.flab.vibeup.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByUserId(Long userId);
+
+    Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable); // 최신순 피드 조회
+
+    Page<Post> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable); // 특정 유저의 피드 조회
 }

--- a/src/main/java/com/flab/vibeup/domain/post/service/PostService.java
+++ b/src/main/java/com/flab/vibeup/domain/post/service/PostService.java
@@ -1,5 +1,7 @@
 package com.flab.vibeup.domain.post.service;
 
+import com.flab.vibeup.domain.follow.entity.Follow;
+import com.flab.vibeup.domain.follow.repository.FollowRepository;
 import com.flab.vibeup.domain.post.dto.PostCreateRequest;
 import com.flab.vibeup.domain.post.dto.PostListResponse;
 import com.flab.vibeup.domain.post.dto.PostReadResponse;
@@ -11,14 +13,19 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
 
   private final PostRepository postRepository;
+  private final FollowRepository followRepository;
+  private final RedisTemplate<String, String> redisTemplate;
 
   @Transactional
   public Long createPost(PostCreateRequest request, Long userId) {
@@ -34,6 +41,15 @@ public class PostService {
             .build();
 
     Post savedPost = postRepository.save(post);
+
+    // 🔥 나를 팔로우하는 유저들에게 feed push (Fan-out)
+    List<Follow> followers = followRepository.findAllByFollowee(user);
+    for (Follow follow : followers) {
+      Long followerId = follow.getFollower().getId();
+      String key = "feed:" + followerId;
+      redisTemplate.opsForList().leftPush(key, savedPost.getId().toString());
+    }
+
     return savedPost.getId();
   }
 

--- a/src/main/java/com/flab/vibeup/domain/post/service/PostService.java
+++ b/src/main/java/com/flab/vibeup/domain/post/service/PostService.java
@@ -90,4 +90,16 @@ public class PostService {
     }
     postRepository.delete(post);
   }
+
+  @Transactional(readOnly = true)
+  public Page<PostListResponse> getFeeds(Pageable pageable) {
+    return postRepository.findAllByOrderByCreatedAtDesc(pageable).map(PostListResponse::from);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<PostListResponse> getFeedsByUser(Long userId, Pageable pageable) {
+    return postRepository
+        .findAllByUserIdOrderByCreatedAtDesc(userId, pageable)
+        .map(PostListResponse::from);
+  }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,6 +23,10 @@ spring:
         default_batch_fetch_size: 100
     show-sql: true                  # 콘솔에 SQL 출력 (dev 전용)
 
+  redis:
+    host: localhost
+    port: 6379
+
 jwt:
   secret: "aUCYJ7HwUTSjUqs6dvbZxu6Cf+XyOkO3yhDGT3LTwHc="
   access-validity-seconds: 3600

--- a/src/test/java/com/flab/vibeup/config/RedisConnectionTest.java
+++ b/src/test/java/com/flab/vibeup/config/RedisConnectionTest.java
@@ -1,14 +1,15 @@
 package com.flab.vibeup.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @SpringBootTest
 public class RedisConnectionTest {
+
     @Autowired
     private RedisTemplate<String, Long> redisTemplate;
 

--- a/src/test/java/com/flab/vibeup/config/RedisConnectionTest.java
+++ b/src/test/java/com/flab/vibeup/config/RedisConnectionTest.java
@@ -1,0 +1,21 @@
+package com.flab.vibeup.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class RedisConnectionTest {
+    @Autowired
+    private RedisTemplate<String, Long> redisTemplate;
+
+    @Test
+    void redisPushAndPullTest() {
+        redisTemplate.opsForList().leftPush("feed:1", 100L);
+        Long postId = redisTemplate.opsForList().leftPop("feed:1");
+        assertThat(postId).isEqualTo(100L);
+    }
+}

--- a/src/test/java/com/flab/vibeup/domain/post/service/PostServiceFanoutTest.java
+++ b/src/test/java/com/flab/vibeup/domain/post/service/PostServiceFanoutTest.java
@@ -1,0 +1,109 @@
+package com.flab.vibeup.domain.post.service;
+
+import com.flab.vibeup.domain.follow.entity.Follow;
+import com.flab.vibeup.domain.follow.repository.FollowRepository;
+import com.flab.vibeup.domain.post.dto.PostCreateRequest;
+import com.flab.vibeup.domain.post.entity.MusicVendor;
+import com.flab.vibeup.domain.post.entity.Post;
+import com.flab.vibeup.domain.post.repository.PostRepository;
+import com.flab.vibeup.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PostServiceFanoutTest {
+  @Mock private PostRepository postRepository;
+  @Mock private FollowRepository followRepository;
+
+  // Redis
+  @Mock private RedisTemplate<String, String> redisTemplate;
+  @Mock private ListOperations<String, String> listOperations;
+
+  @InjectMocks private PostService postService;
+
+  private User author;
+  private User follower1;
+  private User follower2;
+
+  @BeforeEach
+  void setUp() {
+    author = User.builder().id(10L).email("author@ex.com").build();
+    follower1 = User.builder().id(20L).email("f1@ex.com").build();
+    follower2 = User.builder().id(30L).email("f2@ex.com").build();
+  }
+
+  @Test
+  @DisplayName("포스트 작성 시, 팔로워들의 Redis feed에 postId를 push 한다")
+  void createPost_shouldPushPostIdToFollowersFeed() {
+    when(redisTemplate.opsForList()).thenReturn(listOperations);
+
+    // given: 요청 데이터
+    PostCreateRequest request =
+        new PostCreateRequest(
+            MusicVendor.YOUTUBE_MUSIC, "https://music.example/song1", "좋은곡", List.of("#tag"));
+
+    // 모의 저장될 Post (save 후 id가 세팅되어 반환된다고 가정)
+    Post savedPost =
+        Post.builder()
+            .id(100L) // save 이후 id
+            .user(author)
+            .musicUrl(request.musicUrl())
+            .vendor(request.vendor())
+            .caption(request.caption())
+            .hashtags(request.hashtags())
+            .build();
+
+    // postRepository.save(...) 호출 시 savedPost 반환
+    when(postRepository.save(org.mockito.ArgumentMatchers.any(Post.class))).thenReturn(savedPost);
+
+    // followRepository.findAllByFollowee(author) -> 두 팔로워 반환
+    Follow f1 = Follow.builder().follower(follower1).followee(author).build();
+    Follow f2 = Follow.builder().follower(follower2).followee(author).build();
+    when(followRepository.findAllByFollowee(any(User.class))).thenReturn(List.of(f1, f2));
+
+    // when
+    Long resultId = postService.createPost(request, author.getId());
+
+    // then
+    // 반환된 id가 저장된 id인지 확인
+    org.assertj.core.api.Assertions.assertThat(resultId).isEqualTo(100L);
+
+    // Redis에 각 팔로워 키로 leftPush 호출됐는지 검증
+    // key = "feed:{followerId}", value = savedPost.getId().toString()
+    verify(listOperations, times(1)).leftPush(eq("feed:" + follower1.getId()), eq("100"));
+    verify(listOperations, times(1)).leftPush(eq("feed:" + follower2.getId()), eq("100"));
+  }
+
+  @Test
+  @DisplayName("팔로워가 없으면 Redis push가 호출되지 않는다")
+  void createPost_whenNoFollowers_shouldNotPushToRedis() {
+    // given
+    PostCreateRequest request =
+        new PostCreateRequest(
+            MusicVendor.YOUTUBE_MUSIC, "https://music.example/song2", "곡2", List.of("#t"));
+
+    Post savedPost = Post.builder().id(101L).user(author).build();
+    when(postRepository.save(org.mockito.ArgumentMatchers.any(Post.class))).thenReturn(savedPost);
+
+    when(followRepository.findAllByFollowee(any(User.class))).thenReturn(List.of());
+
+    // when
+    Long resultId = postService.createPost(request, author.getId());
+
+    // then
+    org.assertj.core.api.Assertions.assertThat(resultId).isEqualTo(101L);
+    // listOperations.leftPush가 호출되지 않아야 함
+    verify(listOperations, times(0)).leftPush(anyString(), anyString());
+  }
+}

--- a/src/test/java/com/flab/vibeup/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/flab/vibeup/domain/post/service/PostServiceTest.java
@@ -12,6 +12,7 @@ import com.flab.vibeup.domain.post.repository.PostRepository;
 import com.flab.vibeup.domain.user.entity.User;
 import com.flab.vibeup.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -176,5 +177,87 @@ class PostServiceTest {
     // then
     boolean exists = postRepository.existsById(savedPostId);
     assertThat(exists).isFalse();
+  }
+
+  @Test
+  @DisplayName("피드 조회 요청 시, 최신순으로 정렬된 게시글 목록이 반환된다")
+  void getFeed_shouldReturnPostsInDescendingOrder() {
+    // given
+    for (int i = 1; i <= 5; i++) {
+      PostCreateRequest request =
+          new PostCreateRequest(
+              MusicVendor.YOUTUBE_MUSIC,
+              "https://youtube.com/music" + i,
+              "추천곡 " + i,
+              List.of("HashTag" + i));
+      postService.createPost(request, savedUser.getId());
+      try {
+        Thread.sleep(50); // 정렬을 위한 시간 확보
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    // when
+    Pageable pageable = PageRequest.of(0, 3); // 최신 3개
+    Page<PostListResponse> feed = postService.getFeeds(pageable);
+
+    // then
+    assertThat(feed).isNotNull();
+    assertThat(feed.getContent()).hasSize(3);
+
+    List<PostListResponse> contents = feed.getContent();
+    for (int i = 0; i < contents.size() - 1; i++) {
+      assertThat(contents.get(i).createdAt()).isAfterOrEqualTo(contents.get(i + 1).createdAt());
+    }
+  }
+
+  @DisplayName("유저 기반 최신순 피드 조회 테스트")
+  @Test
+  void getFeedByUserId_ShouldReturnFeedsSortedByCreatedAtDesc() {
+    // given
+    Post post1 = Post.builder()
+            .user(savedUser)
+            .musicUrl("https://test.com/1")
+            .vendor(MusicVendor.YOUTUBE_MUSIC)
+            .caption("caption1")
+            .hashtags(List.of("tag1", "tag2"))
+            .createdAt(LocalDateTime.now().minusMinutes(10))
+            .build();
+
+    Post post2 = Post.builder()
+            .user(savedUser)
+            .musicUrl("https://test.com/2")
+            .vendor(MusicVendor.YOUTUBE_MUSIC)
+            .caption("caption2")
+            .hashtags(List.of("tag1", "tag2"))
+            .createdAt(LocalDateTime.now().minusMinutes(5))
+            .build();
+
+    Post post3 = Post.builder()
+            .user(savedUser)
+            .musicUrl("https://test.com/3")
+            .vendor(MusicVendor.YOUTUBE_MUSIC)
+            .caption("caption3")
+            .hashtags(List.of("tag1", "tag2"))
+            .createdAt(LocalDateTime.now())
+            .build();
+
+    postRepository.saveAll(List.of(post1, post2, post3));
+
+    Pageable pageable = PageRequest.of(0, 3); // 최신 3개
+
+    // when
+    Page<PostListResponse> feedPage = postService.getFeedsByUser(savedUser.getId(), pageable);
+
+    // then
+    assertThat(feedPage).hasSize(3);
+
+    List<PostListResponse> feed = feedPage.getContent();
+    assertThat(feed.get(0).createdAt()).isAfter(feed.get(1).createdAt());
+    assertThat(feed.get(1).createdAt()).isAfter(feed.get(2).createdAt());
+
+    assertThat(feed.get(0).musicUrl()).isEqualTo("https://test.com/3");
+    assertThat(feed.get(2).musicUrl()).isEqualTo("https://test.com/1");
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- Close https://github.com/f-lab-edu/VibeUp/issues/22 Feed 조회 API 구현 (최신순/유저 기반)
- Close https://github.com/f-lab-edu/VibeUp/issues/23 Feed 조회 단위 테스트 작성

---

### ✨ 주요 변경 사항
1. **PostService**
   - 새로운 포스트 생성 시 작성자의 팔로워 목록을 조회하여
     각 팔로워의 Redis feed 리스트(`feed:{followerId}`)에 `postId`를 fan-out push
   - 팔로워가 없을 경우 Redis push 생략 처리

2. **FeedService / FeedController**
   - 로그인 유저의 Redis feed 목록을 조회하여 최신 순으로 반환
   - Redis → PostRepository 조합으로 post 상세 데이터 조회

3. **단위 테스트**
   - `PostServiceFanoutTest`: 팔로워 존재 / 미존재 시 Redis push 검증
   - `FeedServiceTest`: feed 리스트 조회 및 Post 매핑 검증

---

### 🧪 테스트
- `PostServiceFanoutTest`  
  - 팔로워 있을 경우: `leftPush` 두 번 호출 검증 ✅  
  - 팔로워 없을 경우: `leftPush` 호출되지 않음 ✅
- `FeedServiceTest`  
  - Redis mock으로 feed id 리스트 반환 후 Post 데이터 매핑 검증 ✅

---

### 📚 기타
- RedisTemplate, ListOperations Mock 설정 개선
- `UnnecessaryStubbingException` 해결 (필요 테스트에서만 stubbing 적용)